### PR TITLE
Fixed dashboard crash if no goals are set

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -25,7 +25,7 @@ class UsersController < ApplicationController
     @applications_total = current_user.jobs.nil? ? 0 : current_user.jobs.count
     @interviews_total = Job.where(status: "Interview").count
     @my_resources_total = Resource.where(user: current_user).count
-    @applications_left_to_reach_goal = (@goal.job_target - @applications_total)
+    @applications_left_to_reach_goal = current_user.goals.empty? ? "N/A" : (@goal.job_target - @applications_total)
 
     # I can see the last 4 applications I sent
     @jobs_preview = current_user.jobs.last(4)


### PR DESCRIPTION
- If user's goals is empty, the KPI for 'applications left until goal reached' will show 'N/A'